### PR TITLE
Update Windows compatibility matrix with missing attack categories

### DIFF
--- a/quick-start/compatibility/README.md
+++ b/quick-start/compatibility/README.md
@@ -127,8 +127,8 @@ The following attacks are available when working with physical hosts and virtual
 | Debian Bullseye     | ✅         | ✅             | ✅                         | ✅                      | ✅                     | ✅                        |
 | Amazon Linux 2      | ✅         | ✅             | ✅                         | ✅                      | ✅                     | ✅                        |
 | Amazon Linux 2023   | ✅         | ✅             | ✅                         | ✅                      | ✅                     | ✅                        |
-| Windows 11          | ✅         | ✅             | ✅                         | ✅                      | ✅                     | ✅                        |
-| Windows Server 2022 | ✅         | ✅             | ✅                         | ✅                      | ✅                     | ✅                        |
+| Windows 11 (x64)          | ✅         | ✅             | ✅                         | ✅                      | ✅                     | ✅                        |
+| Windows Server 2022 (x64) | ✅         | ✅             | ✅                         | ✅                      | ✅                     | ✅                        |
 
 {% hint style="info" %}
 Other .exe, .deb and .rpm-based distributions will mostly likely work, too, but aren't explicitly tested on.
@@ -146,6 +146,8 @@ Other .exe, .deb and .rpm-based distributions will mostly likely work, too, but 
 | Debian Bullseye   | ✅         | ✅           | ✅          | ✅         | ✅             |
 | Amazon Linux 2    | ✅         | ✅           | ✅          | ✅         | ✅             |
 | Amazon Linux 2023 | ✅         | ✅           | ✅          | ✅         | ✅             |
+| Windows 11 (x64)          | ✅         | ✅           | ✅          | ✅         | ❌             |
+| Windows Server 2022 (x64) | ✅         | ✅           | ✅          | ✅         | ❌             |
 
 {% hint style="info" %}
 Other .deb and .rpm-based distributions will mostly likely work, too, but aren't explicitly tested on.
@@ -163,6 +165,8 @@ Other .deb and .rpm-based distributions will mostly likely work, too, but aren't
 | Debian Bullseye   | ✅             | ✅            | ✅           |
 | Amazon Linux 2    | ✅             | ✅            | ✅           |
 | Amazon Linux 2023 | ✅             | ✅            | ✅           |
+| Windows 11 (x64)          | ✅             | ✅            | ✅           |
+| Windows Server 2022 (x64) | ✅             | ✅            | ✅           |
 
 {% hint style="info" %}
 Other .deb and .rpm-based distributions will mostly likely work, too, but aren't explicitly tested on.


### PR DESCRIPTION
## Summary
- Add Windows 11 and Windows Server 2022 (or newer) to **Resource Attacks** table (Fill Disk, Fill Memory, Stress CPU, Stress IO supported; Stress Memory not supported)
- Add Windows 11 and Windows Server 2022 (or newer) to **State Attacks** table (Shutdown Host, Stop Process, Time Travel)
- Clarify that Windows only supports x64 architecture (Linux supports both x64 and ARM)
- Update "Windows Server 2022" to "Windows Server 2022 (or newer)" across all tables

## Test plan
- [ ] Verify the compatibility page renders correctly on GitBook
- [ ] Cross-check attack categories against the [Reliability Hub](https://hub.steadybit.com/extension/com.steadybit.extension_host_windows)