### PR TITLE
doc: On-prem monitoring guide and database runbooks

### DIFF
--- a/.gitbook/assets/steadybit-platform-dashboard.json
+++ b/.gitbook/assets/steadybit-platform-dashboard.json
@@ -1,0 +1,3693 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 9,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 16,
+      "panels": [],
+      "title": "Message Queues",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": true,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (groupKey) (queue_length{app_kubernetes_io_instance=~\"$instance\", groupKey=~\"$queue_group\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Message Queue Length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "mps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": true,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(name) (irate(spring_integration_send_seconds_count{name=~\"$queue_group\", app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Message Creation Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": true,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (groupKey) (queue_lead_time{app_kubernetes_io_instance=~\"$instance\", groupKey=~\"$queue_group\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Message Queue Accumulated Lead Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by(tenantKey)(rate(targets_postprocess_duration_seconds_count{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval]))\n+\nsum by(tenantKey)(rate(targets_postprocesslisten_duration_seconds_count{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Target Post Processing Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "quantile by(tenantKey)(0.95, rate(targets_postprocess_duration_seconds_sum{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval]) / rate(targets_postprocess_duration_seconds_count{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval])) \n+\nquantile by(tenantKey)(0.95, rate(targets_postprocesslisten_duration_seconds_sum{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval]) / rate(targets_postprocesslisten_duration_seconds_count{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Target Post Processing Latency (95th)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "quantile by(processor)(0.95, rate(targets_postprocess_processor_duration_seconds_sum{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval]) / rate(targets_postprocess_processor_duration_seconds_count{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval]))\n",
+          "legendFormat": "{{processor}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "quantile by(listener)(0.95, rate(targets_postprocesslisten_listener_duration_seconds_sum{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval]) / rate(targets_postprocesslisten_listener_duration_seconds_count{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{listener}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Target Post Processing Latency per Processor (95th)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Target Ingestion",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 0,
+        "y": 17
+      },
+      "id": 26,
+      "options": {
+        "displayLabels": [
+          "value"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "sort": "desc",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by(type) (platform_targets_by_type{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"})",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "type {{type}}",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Targets by Type",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 3,
+        "y": 17
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "min",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": true,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by(tenantKey) (platform_targets{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{tenantKey}} targets",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max by(tenantKey) (platform_enrichmentData{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{tenantKey}} enrichmentData",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Target & EnrichmentData Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 49,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 17
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "min",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by(tenantKey, type) (platform_targets_by_type{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{tenantKey}} {{type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max by(tenantKey, type) (platform_enrichmentData_by_type{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{tenantKey}} {{type}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Target & EnrichmentData by Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 17
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(tenantKey, action) (increase(targets_submit_submitted_total{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{tenantKey}} [{{action}}]",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Target Submit Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.20\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83920\", experimentKey=\"CYPRESS-3798\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14074-1\", helm_sh_chart=\"base-1.1.20\", instance=\"10.10.94.65:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5b965c458-p4786\", pod_template_hash=\"5b965c458\", team=\"Cypress Integration Tests\", teamKey=\"CYPRESS\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"wait\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"wait\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83922\", experimentKey=\"CYPRESS-3799\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14075-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.98:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-c76d56bfc-kxxk5\", pod_template_hash=\"c76d56bfc\", team=\"Cypress Integration Tests\", teamKey=\"CYPRESS\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83927\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83927\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83929\", experimentKey=\"ADM-1388\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83932\", experimentKey=\"ADM-963\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.fixed_amount\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"158\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14075-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.98:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-c76d56bfc-kxxk5\", pod_template_hash=\"c76d56bfc\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"UI_EXPERIMENT_LIST\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"159\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"160\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"161\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"162\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"163\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"164\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"165\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"166\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"167\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"168\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"169\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"170\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"171\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"172\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"173\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"174\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"175\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"176\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"177\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"178\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"179\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"180\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"181\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"182\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"183\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"184\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"185\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"186\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"187\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"188\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"189\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"190\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"191\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"192\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"193\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"194\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"195\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"196\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"197\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"198\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"199\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"200\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"201\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"202\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"203\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"204\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"205\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"206\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"207\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"208\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"209\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"210\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"211\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"212\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"213\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"214\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"215\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"216\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"217\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"218\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 0,
+        "y": 25
+      },
+      "id": 33,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by(tenantKey) (platform_agents{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"} > 0)",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Agents registered",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.20\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83920\", experimentKey=\"CYPRESS-3798\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14074-1\", helm_sh_chart=\"base-1.1.20\", instance=\"10.10.94.65:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5b965c458-p4786\", pod_template_hash=\"5b965c458\", team=\"Cypress Integration Tests\", teamKey=\"CYPRESS\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"wait\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"wait\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83922\", experimentKey=\"CYPRESS-3799\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14075-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.98:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-c76d56bfc-kxxk5\", pod_template_hash=\"c76d56bfc\", team=\"Cypress Integration Tests\", teamKey=\"CYPRESS\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83927\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83927\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83929\", experimentKey=\"ADM-1388\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83932\", experimentKey=\"ADM-963\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.fixed_amount\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"158\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14075-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.98:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-c76d56bfc-kxxk5\", pod_template_hash=\"c76d56bfc\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"UI_EXPERIMENT_LIST\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"159\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"160\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"161\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"162\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"163\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"164\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"165\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"166\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"167\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"168\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"169\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"170\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"171\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"172\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"173\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"174\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"175\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"176\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"177\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"178\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"179\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"180\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"181\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"182\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"183\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"184\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"185\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"186\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"187\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"188\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"189\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"190\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"191\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"192\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"193\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"194\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"195\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"196\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"197\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"198\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"199\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"200\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"201\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"202\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"203\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"204\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"205\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"206\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"207\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"208\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"209\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"210\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"211\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"212\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"213\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"214\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"215\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"216\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"217\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"218\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 3,
+        "y": 25
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": true,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by(tenantKey) (platform_agents{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"})",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Agents registered",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 24,
+      "panels": [],
+      "title": "Platform Chaos Engineering Activity",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.2,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bool_yes_no"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 34
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "platform_experiments_executing{tenantKey=~\"$tenant\",app_kubernetes_io_instance=~\"$instance\"} > 0",
+          "legendFormat": "Tenant {{tenantKey}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Experiment(s) running",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "min": 0
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.20\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83920\", experimentKey=\"CYPRESS-3798\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14074-1\", helm_sh_chart=\"base-1.1.20\", instance=\"10.10.94.65:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5b965c458-p4786\", pod_template_hash=\"5b965c458\", team=\"Cypress Integration Tests\", teamKey=\"CYPRESS\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"wait\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"wait\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83922\", experimentKey=\"CYPRESS-3799\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14075-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.98:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-c76d56bfc-kxxk5\", pod_template_hash=\"c76d56bfc\", team=\"Cypress Integration Tests\", teamKey=\"CYPRESS\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83927\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83927\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83929\", experimentKey=\"ADM-1388\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83932\", experimentKey=\"ADM-963\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.fixed_amount\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"158\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14075-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.98:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-c76d56bfc-kxxk5\", pod_template_hash=\"c76d56bfc\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"UI_EXPERIMENT_LIST\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"159\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"160\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"161\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"162\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"163\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"164\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"165\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"166\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"167\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"168\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"169\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"170\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"171\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"172\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"173\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"174\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"175\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"176\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"177\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"178\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"179\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"180\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"181\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"182\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"183\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"184\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"185\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"186\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"187\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"188\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"189\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"190\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"191\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"192\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"193\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"194\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"195\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"196\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"197\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"198\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"199\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"200\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"201\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"202\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"203\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"204\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"205\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"206\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"207\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"208\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"209\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"210\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"211\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"212\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"213\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"214\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"215\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"216\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"217\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"218\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 34
+      },
+      "id": 28,
+      "options": {
+        "displayLabels": [
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "sort": "desc",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(tenantKey) (increase(platform_event_experiment_execution_completed_total{tenantKey=~\"$tenant\",app_kubernetes_io_instance=~\"$instance\"}[$__range])> 0.9)",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Completed - Tenant {{ tenantKey }}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(tenantKey) (increase(platform_event_experiment_execution_failed_total{tenantKey=~\"$Tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__range])> 0.9)",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Failed - Tenant {{ tenantKey }}",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(tenantKey) (increase(platform_event_experiment_execution_errored_total{tenantKey=~\"$Tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__range]))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Errored - Tenant {{ tenantKey }}",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(tenantKey) (increase(platform_event_experiment_execution_errored_after_started_total{tenantKey=~\"$Tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__range])> 0.9)",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Errored after started - Tenant {{ tenantKey }}",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(tenantKey) (increase(platform_event_experiment_execution_canceled_total{tenantKey=~\"$Tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__range])> 0.9)",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Canceled - Tenant {{ tenantKey }}",
+          "range": true,
+          "refId": "E",
+          "useBackend": false
+        }
+      ],
+      "title": "Execution Summary (Last) (Per Tenant)",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.20\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83920\", experimentKey=\"CYPRESS-3798\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14074-1\", helm_sh_chart=\"base-1.1.20\", instance=\"10.10.94.65:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5b965c458-p4786\", pod_template_hash=\"5b965c458\", team=\"Cypress Integration Tests\", teamKey=\"CYPRESS\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"wait\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"wait\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83922\", experimentKey=\"CYPRESS-3799\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14075-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.98:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-c76d56bfc-kxxk5\", pod_template_hash=\"c76d56bfc\", team=\"Cypress Integration Tests\", teamKey=\"CYPRESS\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83927\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83927\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83929\", experimentKey=\"ADM-1388\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83932\", experimentKey=\"ADM-963\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.fixed_amount\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"158\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14075-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.98:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-c76d56bfc-kxxk5\", pod_template_hash=\"c76d56bfc\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"UI_EXPERIMENT_LIST\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"159\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"160\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"161\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"162\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"163\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"164\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"165\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"166\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"167\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"168\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"169\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"170\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"171\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"172\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"173\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"174\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"175\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"176\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"177\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"178\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"179\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"180\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"181\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"182\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"183\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"184\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"185\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"186\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"187\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"188\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"189\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"190\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"191\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"192\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"193\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"194\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"195\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"196\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"197\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"198\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"199\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"200\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"201\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"202\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"203\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"204\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"205\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"206\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"207\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"208\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"209\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"210\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"211\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"212\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"213\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"214\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"215\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"216\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"217\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"218\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "id": 29,
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "top",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (experimentStepExecutionActionId) (increase(experiment_execution_step_completed_total{app_kubernetes_io_instance=~\"$instance\",tenantKey=~\"$tenant\"}[$__range]) > 0)",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{ experimentStepExecutionActionId }}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Experiment Steps Completed (Per Tenant)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 42
+      },
+      "id": 25,
+      "options": {
+        "displayLabels": [
+          "value",
+          "name"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "sort": "desc",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(tenantKey) (changes(platform_experiments_executing{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"}[7d]) / 2 >= 0.9)",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Tenant {{tenantKey}}",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Experiments executed (7 days)",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Time"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 42
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (tenantKey) (increase(experiment_execution_step_completed_total{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__range]))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Completed - Tenant {{ tenantKey }}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (tenantKey) (increase(experiment_execution_step_failed_total{tenantKey=~\"$Tenant\"}[$__range]))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Failed - Tenant {{ tenantKey }}",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (tenantKey) (increase(experiment_execution_step_canceled_total{tenantKey=~\"$Tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__range]))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Canceled - Tenant {{ tenantKey }}",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(tenantKey) (increase(experiment_execution_step_errored_total{tenantKey=~\"$Tenant\", app_kubernetes_io_instance=~\"$instance\"}[$__range]))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Errored - Tenant {{ tenantKey }}",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        }
+      ],
+      "title": "Experiment Steps Summary (Per Tenant)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.20\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83920\", experimentKey=\"CYPRESS-3798\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14074-1\", helm_sh_chart=\"base-1.1.20\", instance=\"10.10.94.65:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5b965c458-p4786\", pod_template_hash=\"5b965c458\", team=\"Cypress Integration Tests\", teamKey=\"CYPRESS\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83924\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"wait\", github_run=\"14077-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.85.112:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-585fb5d4fc-6qrcj\", pod_template_hash=\"585fb5d4fc\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83938\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83939\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.92.210:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-kjkmp\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83940\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"wait\", github_run=\"14096-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.214:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-57c5ff44c7-4r2jj\", pod_template_hash=\"57c5ff44c7\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.periodically\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_jvm.spring-mvc-exception-attack\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"GitHubAction / Onlineshop\", environmentId=\"a7efb4f1-9b8e-46a7-a3eb-ffc29ba75eae\", experimentExecutionId=\"83941\", experimentKey=\"GITHUB-204\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14100-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-5bb8d6b6f-v9ns6\", pod_template_hash=\"5bb8d6b6f\", team=\"GitHub Action\", teamKey=\"GITHUB\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83922\", experimentKey=\"CYPRESS-3799\", experimentStepExecutionActionId=\"com.steadybit.extension_container.stop\", github_run=\"14075-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.98:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-c76d56bfc-kxxk5\", pod_template_hash=\"c76d56bfc\", team=\"Cypress Integration Tests\", teamKey=\"CYPRESS\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83927\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83927\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83929\", experimentKey=\"ADM-1388\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83932\", experimentKey=\"ADM-963\", experimentStepExecutionActionId=\"com.steadybit.extension_http.check.fixed_amount\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83936\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14086-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.211:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-d8d4cf4b-g28h2\", pod_template_hash=\"d8d4cf4b\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_container.network_blackhole\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_check\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.pod_count_metric\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_prometheus.instance.metrics\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83937\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"wait\", github_run=\"14094-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-65d89f9565-dz6mk\", pod_template_hash=\"65d89f9565\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"158\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14075-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.98:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-c76d56bfc-kxxk5\", pod_template_hash=\"c76d56bfc\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"UI_EXPERIMENT_LIST\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"159\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"160\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"161\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"162\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"163\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"164\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"165\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"166\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"167\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"168\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"169\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"170\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"171\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"172\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"173\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"174\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"175\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"176\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"177\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"178\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"179\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"180\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"181\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"182\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"183\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"184\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"185\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"186\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"187\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"188\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"189\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"190\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"191\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"192\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"193\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"194\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"195\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"196\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"197\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"198\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"199\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"200\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"201\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"202\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"203\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"204\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"205\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"206\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"207\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"208\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"209\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"210\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"211\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"212\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"213\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"214\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"215\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"216\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"217\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"84e3ff03-7c6c-461f-bee3-acc5b35cf65d\", experimentExecutionId=\"218\", experimentKey=\"REP-1\", experimentStepExecutionActionId=\"wait\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.94.123:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mdpdb\", pod_template_hash=\"84bc459bb7\", team=\"REPORTING TEAM\", teamKey=\"REP\", tenantKey=\"dev_ea_1920\", triggeredVia=\"SCHEDULE\"}",
+                  "{app_kubernetes_io_instance=\"platform\", app_kubernetes_io_managed_by=\"Helm\", app_kubernetes_io_name=\"platform\", app_kubernetes_io_version=\"1.1.21\", environment=\"Global\", environmentId=\"42e59a61-8322-42f2-bad9-307dc962ec37\", experimentExecutionId=\"83934\", experimentKey=\"ADM-1375\", experimentStepExecutionActionId=\"com.steadybit.extension_kubernetes.kubernetes_logs\", github_run=\"14082-1\", helm_sh_chart=\"base-1.1.21\", instance=\"10.10.81.217:9090\", job=\"kubernetes-pods\", kubernetes_namespace=\"platform\", kubernetes_pod_name=\"platform-84bc459bb7-mn9ww\", pod_template_hash=\"84bc459bb7\", team=\"Administrators\", teamKey=\"ADM\", tenantKey=\"demo\", triggeredVia=\"UI_EXPERIMENT_EDITOR\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 12,
+        "y": 42
+      },
+      "id": 30,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sort(avg by(tenantKey) (platform_users_active{tenantKey=~\"$tenant\", app_kubernetes_io_instance=~\"$instance\"} > 0))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Number of active users",
+      "type": "barchart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Platform Resources Consumption",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 51
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "process_cpu_usage{app_kubernetes_io_instance=~\"$instance\"}",
+          "instant": false,
+          "legendFormat": "process {{kubernetes_pod_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Platform CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 51
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name) (executor_active_threads{app_kubernetes_io_instance=~\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{name}} active threads",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name) (executor_pool_size_threads{app_kubernetes_io_instance=~\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{name}} allocated threads",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Thread Pool Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 60
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by(pool) (hikaricp_connections{ app_kubernetes_io_instance=~\"$instance\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Datasource connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 60
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by(jobName) (quartz_job_execution_seconds_count{app_kubernetes_io_instance=~\"$instance\", tenantKey=~\"$tenant\"})",
+          "legendFormat": "{{tenantKey}} - {{jobName}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Quarz Job Activity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Outgoing Webhook and Hub requests",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Blocked"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 68
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(status) (increase(connectivity_outgoing_address_filter_total{app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval]))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Outgoing Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "warn"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^(?!error)(?!warn).*$/"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 68
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(level) (irate(logback_events_total{app_kubernetes_io_instance=~\"$instance\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Platform Log Events",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 76
+      },
+      "id": 40,
+      "panels": [],
+      "title": "Traces",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 77
+      },
+      "id": 42,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "filters": [
+            {
+              "id": "06405704",
+              "isCustomValue": false,
+              "operator": "=",
+              "scope": "resource",
+              "value": [],
+              "valueType": "string"
+            },
+            {
+              "id": "min-duration",
+              "operator": ">=",
+              "tag": "duration",
+              "value": "100ms",
+              "valueType": "duration"
+            },
+            {
+              "id": "service-name",
+              "isCustomValue": false,
+              "operator": "=",
+              "scope": "resource",
+              "tag": "service.name",
+              "value": [
+                "platform"
+              ],
+              "valueType": "string"
+            },
+            {
+              "id": "span-name",
+              "isCustomValue": false,
+              "operator": "!=",
+              "scope": "span",
+              "tag": "name",
+              "value": [
+                "GET /actuator/prometheus",
+                "GET /actuator/{id}"
+              ],
+              "valueType": "string"
+            }
+          ],
+          "limit": 20,
+          "metricsQueryType": "range",
+          "query": "{duration>=100ms && resource.service.name=\"platform\" && (name!=\"GET /actuator/prometheus\" && name!=\"GET /actuator/{id}\") && span:kind = server}",
+          "queryType": "traceql",
+          "refId": "A",
+          "serviceMapUseNativeHistograms": false,
+          "tableType": "traces"
+        }
+      ],
+      "title": "🐌 Traces over 100ms",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 77
+      },
+      "id": 43,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "filters": [
+            {
+              "id": "06405704",
+              "isCustomValue": false,
+              "operator": "=",
+              "scope": "resource",
+              "value": [],
+              "valueType": "string"
+            },
+            {
+              "id": "min-duration",
+              "operator": ">=",
+              "tag": "duration",
+              "value": "",
+              "valueType": "duration"
+            },
+            {
+              "id": "service-name",
+              "isCustomValue": false,
+              "operator": "=",
+              "scope": "resource",
+              "tag": "service.name",
+              "value": [
+                "platform"
+              ],
+              "valueType": "string"
+            },
+            {
+              "id": "span-name",
+              "isCustomValue": false,
+              "operator": "!=",
+              "scope": "span",
+              "tag": "name",
+              "value": [
+                "GET /actuator/prometheus",
+                "GET /actuator/{id}"
+              ],
+              "valueType": "string"
+            },
+            {
+              "id": "status",
+              "isCustomValue": false,
+              "operator": "=",
+              "scope": "intrinsic",
+              "tag": "status",
+              "value": "error",
+              "valueType": "keyword"
+            }
+          ],
+          "limit": 100,
+          "metricsQueryType": "range",
+          "query": "{resource.service.name=\"platform\" && (name!=\"GET /actuator/prometheus\" && name!=\"GET /actuator/{id}\") && status=error && span:kind = server}",
+          "queryType": "traceql",
+          "refId": "A",
+          "serviceMapUseNativeHistograms": false,
+          "tableType": "traces"
+        }
+      ],
+      "title": "🔴 All error traces",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 24,
+        "x": 0,
+        "y": 85
+      },
+      "id": 39,
+      "options": {
+        "edges": {},
+        "layoutAlgorithm": "layered",
+        "nodes": {
+          "arcs": [
+            {
+              "color": "",
+              "field": ""
+            }
+          ]
+        },
+        "zoomMode": "cooperative"
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "limit": 20,
+          "metricsQueryType": "range",
+          "queryType": "serviceMap",
+          "refId": "A",
+          "serviceMapQuery": "{}",
+          "serviceMapUseNativeHistograms": false,
+          "tableType": "traces"
+        }
+      ],
+      "title": "Service Graph",
+      "type": "nodeGraph"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "label_values(tenantKey)",
+        "includeAll": true,
+        "label": "Tenant",
+        "multi": true,
+        "name": "tenant",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(tenantKey)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "definition": "label_values(platform_agents,app_kubernetes_io_instance)",
+        "includeAll": true,
+        "label": "Instance",
+        "name": "instance",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(platform_agents,app_kubernetes_io_instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "label_values(queue_length,groupKey)",
+        "includeAll": true,
+        "label": "Message Queue",
+        "multi": true,
+        "name": "queue_group",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(queue_length,groupKey)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Steadybit Platform",
+  "uid": "1",
+  "version": 6
+}

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -35,6 +35,8 @@
   * [Install on Minikube](install-and-configure/install-on-prem-platform/minikube.md)
   * [Advanced Agent Authentication](install-and-configure/install-on-prem-platform/advanced-agent-authentication.md)
   * [Configuration Options](install-and-configure/install-on-prem-platform/advanced-configuration.md)
+  * [Monitoring the Platform](install-and-configure/install-on-prem-platform/monitoring.md)
+  * [Database Runbooks](install-and-configure/install-on-prem-platform/database-runbooks.md)
   * [Maintenance & Incident Support](install-and-configure/install-on-prem-platform/maintenance-and-incident-support.md)
   * [OIDC Integration](install-and-configure/install-on-prem-platform/oidc-integration.md)
   * [LDAP Integration](install-and-configure/install-on-prem-platform/ldap-integration.md)

--- a/install-and-configure/install-on-prem-platform/database-runbooks.md
+++ b/install-and-configure/install-on-prem-platform/database-runbooks.md
@@ -1,0 +1,159 @@
+---
+title: Database Runbooks
+navTitle: Database Runbooks
+---
+
+# Database Runbooks
+
+{% hint style="info" %}
+This page applies to **on-premise installations** of the Steadybit platform. It assumes you are running a PostgreSQL 15+ database that the platform connects to. See [Database Configuration](advanced-configuration.md#database-configuration) for connection settings.
+{% endhint %}
+
+The Steadybit platform is heavily backed by PostgreSQL. Two operational situations come up often enough to warrant a runbook:
+
+1. [The connection pool is saturated by long-running or blocked transactions.](#blocking-transactions)
+2. [The database is running out of disk space.](#running-out-of-disk-space)
+
+In both cases, monitoring should give you advance warning — see [Monitoring the Platform](monitoring.md) for the alerts we recommend.
+
+{% hint style="warning" %}
+The queries below modify production data. Always run a `SELECT` first to confirm the scope, and take a backup before running `DELETE` or `pg_terminate_backend`. If you are unsure, [contact Steadybit support](https://www.steadybit.com/contact) before proceeding.
+{% endhint %}
+
+## Blocking Transactions
+
+**Symptom:** the `SteadybitHikariPoolCritical` alert fires, target updates from agents are not being processed, or the UI feels stuck on operations that read or write the `target` table.
+
+**Cause:** PostgreSQL transactions that started but were never committed or rolled back continue to hold row-level locks. New connections from the platform queue up waiting for those locks and the HikariCP connection pool fills up.
+
+### Step 1 — List transactions that hold locks
+
+```sql
+SELECT a.datname,
+       l.relation::regclass,
+       l.transactionid,
+       l.mode,
+       l.granted,
+       a.usename,
+       a.query,
+       a.query_start,
+       age(now(), a.query_start) AS age,
+       a.pid
+FROM pg_stat_activity a
+JOIN pg_locks l ON l.pid = a.pid
+ORDER BY a.query_start;
+```
+
+### Step 2 — Narrow down to transactions older than 1 hour
+
+Most legitimate platform queries finish in under a second. Anything older than an hour is almost certainly stuck.
+
+```sql
+SELECT a.pid,
+       a.query,
+       a.query_start,
+       age(now(), a.query_start) AS age
+FROM pg_stat_activity a
+JOIN pg_locks l ON l.pid = a.pid
+WHERE a.query_start < now() - INTERVAL '1 hour'
+ORDER BY a.query_start;
+```
+
+### Step 3 — Terminate the offending backend
+
+Replace `<pid>` with the process ID returned by the previous query:
+
+```sql
+SELECT pg_terminate_backend(<pid>);
+```
+
+`pg_terminate_backend` rolls back the transaction and closes the connection. The platform reconnects automatically; no restart is required.
+
+### Step 4 — Verify recovery
+
+* Re-run the query from Step 1 — the count of held locks should drop.
+* Check the `Datasource connections` panel; `hikaricp_connections_active` should fall back to its baseline.
+* Confirm that the message queue lead time (`queue_lead_time`) starts decreasing.
+
+## Running Out of Disk Space
+
+**Symptom:** Postgres logs report `could not extend file` or `No space left on device`, or your storage monitoring is approaching the volume capacity.
+
+**Cause:** historical execution data, target snapshots, or audit log entries have accumulated beyond what the configured retention removes. Bloat in heavily updated tables (notably `target`) can also consume far more space than the live row count would suggest.
+
+### Step 1 — Identify the largest tables
+
+```sql
+SELECT nspname AS schema,
+       relname AS table,
+       reltuples AS row_estimate,
+       pg_size_pretty(pg_total_relation_size(c.oid))           AS total,
+       pg_size_pretty(pg_indexes_size(c.oid))                  AS index,
+       pg_size_pretty(pg_total_relation_size(reltoastrelid))   AS toast,
+       pg_size_pretty(pg_total_relation_size(c.oid)
+                      - pg_indexes_size(c.oid)
+                      - COALESCE(pg_total_relation_size(reltoastrelid), 0)) AS table_only
+FROM pg_class c
+LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE relkind = 'r'
+ORDER BY pg_total_relation_size(c.oid) DESC
+LIMIT 20;
+```
+
+The most common offenders are:
+
+| Table | Why it grows |
+|-------|--------------|
+| `target` | Snapshot of every target seen by every agent. Heavy update churn → bloat. |
+| `target_stats`, `target_submission_tracking` | Per-submission counters that the platform vacuums periodically. |
+| `audit_log` | One row per administrative action. |
+| `experiment_execution`, `execution_log_event`, `execution_metric_event` | Grow with the number of experiment runs. |
+
+### Step 2 — Reclaim space with VACUUM
+
+The platform runs scheduled `VACUUM`/`ANALYZE` (see `STEADYBIT_DB_MAINTENANCE_*` in [Configuration Options](advanced-configuration.md#database-maintenance)). When you need to reclaim space immediately, run a full vacuum **on a low-traffic window** — `VACUUM FULL` takes an exclusive lock on the affected table:
+
+```sql
+-- Releases space back to the OS but locks the table.
+VACUUM FULL;
+
+-- Or, target a single table:
+VACUUM FULL public.target;
+```
+
+For a non-blocking alternative on PostgreSQL, install and use [`pg_repack`](https://reorg.github.io/pg_repack/).
+
+### Step 3 — Delete obsolete data (if needed)
+
+Only delete data after confirming that the platform's built-in retention is not enough for your situation, and after taking a backup. The data the platform tolerates losing the most are old target snapshots:
+
+```sql
+-- Replace the cutoff with a date well before your current retention horizon.
+DELETE FROM public.target WHERE timestamp < '2025-01-01 00:00:00';
+```
+
+After a large delete, run `VACUUM FULL` on the affected table again to release the space.
+
+### Step 4 — Increase the volume size
+
+If after vacuuming, the database is still close to full, the safest fix is to increase the underlying volume. On AWS RDS this is a non-disruptive operation; on a self-hosted Postgres, follow your storage provider's resize procedure.
+
+Plan ahead by reviewing your [Machine Requirements](advanced-configuration.md#rds-machine-requirements) — at ~100 k targets we recommend at least 20 GB of database storage.
+
+## Preventive Maintenance
+
+The platform performs automatic maintenance on a configurable schedule. The defaults are sensible for most installations; review them if you operate at scale or have observed bloat.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STEADYBIT_DB_MAINTENANCE_ENABLED` | `true` | Enable automatic VACUUM/ANALYZE. |
+| `STEADYBIT_DB_MAINTENANCE_CRON` | `0 0 0 ? * SAT *` | Saturday at midnight. |
+| `STEADYBIT_DB_MAINTENANCE_TABLES` | see [Configuration Options](advanced-configuration.md#database-maintenance) | Tables included in the maintenance window. |
+
+Combined with the alerts described in [Monitoring the Platform](monitoring.md), this is usually enough to keep the database healthy without manual intervention.
+
+## Related Pages
+
+* [Monitoring the Platform](monitoring.md) — alerts that warn you before these situations become critical.
+* [Configuration Options › Database Configuration](advanced-configuration.md#database-configuration) — connection and maintenance settings.
+* [Troubleshooting › On-prem platform](../../troubleshooting/common-fixes/on-prem-platform.md) — installation-time database issues.

--- a/install-and-configure/install-on-prem-platform/database-runbooks.md
+++ b/install-and-configure/install-on-prem-platform/database-runbooks.md
@@ -9,7 +9,7 @@ navTitle: Database Runbooks
 This page applies to **on-premise installations** of the Steadybit platform. It assumes you are running a PostgreSQL 15+ database that the platform connects to. See [Database Configuration](advanced-configuration.md#database-configuration) for connection settings.
 {% endhint %}
 
-The Steadybit platform is heavily backed by PostgreSQL. Two operational situations come up often enough to warrant a runbook:
+The Steadybit platform stores its state in PostgreSQL. This page covers two operational scenarios:
 
 1. [The connection pool is saturated by long-running or blocked transactions.](#blocking-transactions)
 2. [The database is running out of disk space.](#running-out-of-disk-space)

--- a/install-and-configure/install-on-prem-platform/monitoring.md
+++ b/install-and-configure/install-on-prem-platform/monitoring.md
@@ -13,7 +13,7 @@ When you operate the Steadybit platform yourself, observing a small set of metri
 
 * the metrics endpoint exposed by the platform,
 * the **four Golden Signals** to monitor (latency, traffic, errors, saturation),
-* the dashboard panels we use internally,
+* a downloadable Grafana dashboard — the same one we use internally,
 * a ready-to-use set of **recommended Prometheus alert rules** with the thresholds we run in production.
 
 ## Metrics Endpoint

--- a/install-and-configure/install-on-prem-platform/monitoring.md
+++ b/install-and-configure/install-on-prem-platform/monitoring.md
@@ -1,0 +1,262 @@
+---
+title: Monitoring the Steadybit Platform
+navTitle: Monitoring
+---
+
+# Monitoring the Platform
+
+{% hint style="info" %}
+This page applies to **on-premise installations** of the Steadybit platform. If you are using our SaaS at [platform.steadybit.com](https://platform.steadybit.com), monitoring is fully managed by Steadybit.
+{% endhint %}
+
+When you operate the Steadybit platform yourself, observing a small set of metrics is enough to spot the vast majority of issues before they impact your users. This page describes:
+
+* the metrics endpoint exposed by the platform,
+* the **four Golden Signals** to monitor (latency, traffic, errors, saturation),
+* the dashboard panels we use internally,
+* a ready-to-use set of **recommended Prometheus alert rules** with the thresholds we run in production.
+
+## Metrics Endpoint
+
+The platform exposes Prometheus-compatible metrics on the management port `9090`:
+
+```
+http://<platform-host>:9090/actuator/prometheus
+```
+
+Port `9090` is administrative and is not exposed to end users. Scrape it from your Prometheus instance the same way you would any Spring Boot Actuator endpoint. All metric names referenced on this page come from this endpoint.
+
+## The Four Golden Signals
+
+Monitor these four families first. They cover almost every customer-facing problem.
+
+### 1. Latency
+
+How long requests take to complete. Two views matter:
+
+| Signal | Metric | What it tells you |
+|--------|--------|-------------------|
+| HTTP request latency | `http_server_requests_seconds_sum` / `http_server_requests_seconds_count` | End-user perceived UI/API responsiveness. |
+| Message queue lead time | `queue_lead_time` | How far behind the platform is in processing target updates from agents. Spikes here are the earliest symptom of an overloaded platform. |
+
+**Recommended thresholds:**
+
+| Metric | Warning | Critical |
+|--------|---------|----------|
+| Mean GET response time (2 min window) | > 200 ms | > 500 ms |
+| Mean POST response time (2 min window) | > 400 ms | > 600 ms |
+| Mean POST response time, UI endpoints (`/ui/experiments/validate`, `/ui/targets/count`) | > 5 s | > 10 s |
+| Message queue accumulated lead time | > 10 min | > 30 min |
+
+### 2. Traffic
+
+Request volume hitting the platform. Sudden spikes often correlate with too many agents reconnecting or a misbehaving integration.
+
+| Metric | Warning | Critical |
+|--------|---------|----------|
+| `http_server_requests_seconds_count` per second | > 5 req/s | > 10 req/s |
+
+These thresholds are conservative; tune them to match your installed scale (number of agents, tenants, targets).
+
+### 3. Errors
+
+The percentage of requests returning HTTP 5xx.
+
+| Metric | Critical |
+|--------|----------|
+| `http_server_requests_seconds_count{status=~"5.."}` / total request rate | > 5 % over 5 minutes |
+
+A sustained error rate above 5 % almost always points to a database issue, a broken upstream integration, or a recently failed deployment.
+
+### 4. Saturation
+
+How "full" the platform is. The two limits to watch:
+
+| Resource | Metric | Warning | Critical |
+|----------|--------|---------|----------|
+| JVM heap memory | `jvm_memory_used_bytes{area="heap"}` / `jvm_memory_max_bytes{area="heap"}` | > 80 % for 5 min | — |
+| Database connection pool | `hikaricp_connections_active` / `hikaricp_connections_max` | > 60 % for 5 min | > 80 % for 5 min |
+
+A connection pool above 80 % is a strong indicator of either long-running transactions on the database or an undersized pool. See the [Database Runbooks](database-runbooks.md) page for cleanup procedures.
+
+## Dashboard Panels
+
+The internal Grafana dashboard we operate is grouped into the following sections. We recommend you replicate this structure in your own observability stack.
+
+### Message Queues
+
+Tracks the asynchronous pipeline that ingests target updates from agents and feeds them into the platform.
+
+| Panel | Metric | What to watch for |
+|-------|--------|-------------------|
+| Message Queue Length | `queue_size` | A non-zero value sustained for minutes means the platform is falling behind. |
+| Message Creation Rate | rate of `queue_messages_total` | Incoming load. Compare with throughput. |
+| Message Queue Accumulated Lead Time | `queue_lead_time` | Most important latency indicator for ingestion. |
+| Target Post Processing Throughput | rate of `target_post_processing_seconds_count` | Should match or exceed the creation rate. |
+| Target Post Processing Latency (p95) | `target_post_processing_seconds` | Per-processor breakdown helps identify slow steps. |
+
+### Target Ingestion
+
+Validates that targets discovered by agents are being received and stored.
+
+| Panel | What it shows |
+|-------|---------------|
+| Targets by Type | Distribution of target types currently in the platform. |
+| Target & EnrichmentData Count / by Type | Total target count over time — a sudden drop is a red flag. |
+| Target Submit Count | Submissions per second from agents. |
+| Agents registered | Count of agents currently connected per tenant. A drop indicates connectivity loss. |
+
+### Platform Chaos Engineering Activity
+
+Business-level signals that confirm Steadybit is being used.
+
+| Panel | Metric |
+|-------|--------|
+| Experiment(s) running | `platform.experiments.executing` |
+| Experiments executed (7 days) | Long-window counter, useful as a lagging indicator. |
+| Number of active users | Useful before maintenance windows. See [Maintenance & Incident Support](maintenance-and-incident-support.md). |
+
+### Platform Resource Consumption
+
+The infrastructure-level signals to alert on.
+
+| Panel | Metric |
+|-------|--------|
+| Platform CPU Usage | `process_cpu_usage` |
+| Thread Pool Usage | `executor_active_threads` per executor |
+| Datasource connections | `hikaricp_connections_active` per pool |
+| Quartz Job Activity | Background jobs running on schedule. |
+| Outgoing Requests | `connectivity_outgoing_address_filter_total` (allowed / blocked) |
+| Platform Log Events | Rate of `error` and `warn` log lines. |
+
+## Recommended Prometheus Alert Rules
+
+The following `PrometheusRule` is the exact configuration we run in production. Adjust the thresholds to your scale, but keep the structure — each rule maps to a Golden Signal above.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: steadybit-platform-golden-signals
+  labels:
+    release: prometheus
+spec:
+  groups:
+    - name: GoldenSignalsAlerts
+      rules:
+        # ---------------- Latency ----------------
+        - alert: SteadybitQueueLeadTimeCritical
+          expr: max by (groupKey) (queue_lead_time) > 1800
+          for: 10m
+          labels: { severity: critical }
+          annotations:
+            summary: "Message queue lead time critical"
+            description: "Queue lead time has been above 30 minutes for 10 minutes."
+
+        - alert: SteadybitQueueLeadTimeWarning
+          expr: |
+            max by (groupKey) (queue_lead_time) > 600 and
+            max by (groupKey) (queue_lead_time) < 1800
+          for: 5m
+          labels: { severity: warning }
+          annotations:
+            summary: "Message queue lead time elevated"
+
+        - alert: SteadybitGetLatencyCritical
+          expr: |
+            sum(rate(http_server_requests_seconds_sum{method="GET",exception="none",app_kubernetes_io_name="platform"}[2m])) by (uri)
+            /
+            sum(rate(http_server_requests_seconds_count{method="GET",exception="none",app_kubernetes_io_name="platform"}[2m])) by (uri) > 0.5
+          for: 5m
+          labels: { severity: critical }
+
+        - alert: SteadybitPostLatencyCritical
+          expr: |
+            sum(rate(http_server_requests_seconds_sum{method="POST",exception="none",app_kubernetes_io_name="platform"}[2m])) by (uri)
+            /
+            sum(rate(http_server_requests_seconds_count{method="POST",exception="none",app_kubernetes_io_name="platform"}[2m])) by (uri) > 0.6
+          for: 2m
+          labels: { severity: critical }
+
+        # ---------------- Traffic ----------------
+        - alert: SteadybitRequestRateCritical
+          expr: irate(http_server_requests_seconds_count{exception="none",app_kubernetes_io_name="platform"}[1m]) > 10
+          for: 1m
+          labels: { severity: critical }
+
+        # ---------------- Errors ----------------
+        - alert: SteadybitErrorRateCritical
+          expr: |
+            sum(rate(http_server_requests_seconds_count{app_kubernetes_io_name="platform",status=~"5.."}[1m]))
+            /
+            sum(rate(http_server_requests_seconds_count{app_kubernetes_io_name="platform"}[1m])) > 0.05
+          for: 5m
+          labels: { severity: critical }
+          annotations:
+            summary: "Platform 5xx error rate above 5%"
+
+        # ---------------- Saturation ----------------
+        - alert: SteadybitJvmHeapWarning
+          expr: |
+            sum(jvm_memory_used_bytes{app_kubernetes_io_instance="platform",area="heap"})
+            /
+            sum(jvm_memory_max_bytes{app_kubernetes_io_instance="platform",area="heap"}) > 0.8
+          for: 5m
+          labels: { severity: warning }
+
+        - alert: SteadybitHikariPoolWarning
+          expr: |
+            (sum(hikaricp_connections_active) by (pool) / sum(hikaricp_connections_max) by (pool)) * 100 >= 60
+            and
+            (sum(hikaricp_connections_active) by (pool) / sum(hikaricp_connections_max) by (pool)) * 100 < 80
+          for: 1m
+          labels: { severity: warning }
+          annotations:
+            summary: "HikariCP pool {{ $labels.pool }} > 60 % utilized"
+
+        - alert: SteadybitHikariPoolCritical
+          expr: |
+            (sum(hikaricp_connections_active) by (pool) / sum(hikaricp_connections_max) by (pool)) * 100 >= 80
+          for: 1m
+          labels: { severity: critical }
+          annotations:
+            summary: "HikariCP pool {{ $labels.pool }} > 80 % utilized"
+```
+
+### Optional: Security & Rate Limit Alerts
+
+If your platform is exposed to user-defined webhooks or hubs, the following alerts help catch abusive or misconfigured integrations:
+
+```yaml
+- alert: SteadybitBlockedOutgoingRequests
+  expr: sum by(status) (increase(connectivity_outgoing_address_filter_total{status="blocked"}[1m])) > 5
+  for: 1m
+  labels: { severity: warning }
+  annotations:
+    summary: "Outgoing webhook or hub requests are being blocked"
+
+- alert: SteadybitTenantRateLimitReached
+  expr: |
+    avg by (tenantKey, bucketName) (avg_over_time((ratelimit_tokens_available{qualifier="none"})[10m:])) <= 1
+  labels: { severity: warning }
+  annotations:
+    summary: "Tenant rate limit reached: tenant={{ $labels.tenantKey }}, bucket={{ $labels.bucketName }}"
+```
+
+## When an Alert Fires
+
+| Alert | First thing to check |
+|-------|----------------------|
+| Queue lead time | Database CPU and HikariCP saturation. The post-processing pipeline writes to Postgres on every step. |
+| GET / POST latency | Database, then JVM heap. |
+| 5xx error rate | Platform logs (`Platform Log Events` panel) for stack traces. |
+| JVM heap > 80 % | Capture a heap dump as described in [Troubleshooting › On-prem platform](../../troubleshooting/common-fixes/on-prem-platform.md#create-heap-dump). |
+| HikariCP pool > 80 % | Long-running or blocked transactions. Follow the [Database Runbooks](database-runbooks.md). |
+| Blocked outgoing requests | A user webhook or hub points to a host that is blocked by your egress policy. |
+
+## Related Pages
+
+* [Database Runbooks](database-runbooks.md) — recover from blocking transactions or disk pressure.
+* [Configuration Options](advanced-configuration.md) — JVM and database tuning parameters.
+* [Maintenance & Incident Support](maintenance-and-incident-support.md) — communicate planned maintenance and incidents to your users.
+* [Troubleshooting › On-prem platform](../../troubleshooting/common-fixes/on-prem-platform.md) — common fixes for installation issues.

--- a/install-and-configure/install-on-prem-platform/monitoring.md
+++ b/install-and-configure/install-on-prem-platform/monitoring.md
@@ -79,55 +79,13 @@ How "full" the platform is. The two limits to watch:
 
 A connection pool above 80 % is a strong indicator of either long-running transactions on the database or an undersized pool. See the [Database Runbooks](database-runbooks.md) page for cleanup procedures.
 
-## Dashboard Panels
+## Grafana Dashboard
 
-The internal Grafana dashboard we operate is grouped into the following sections. We recommend you replicate this structure in your own observability stack.
+We publish the same Grafana dashboard we use to operate Steadybit SaaS. It is grouped into four sections — Message Queues, Target Ingestion, Platform Chaos Engineering Activity, and Platform Resource Consumption — each backed by the metrics described above.
 
-### Message Queues
+**Download:** [steadybit-platform-dashboard.json](../../.gitbook/assets/steadybit-platform-dashboard.json)
 
-Tracks the asynchronous pipeline that ingests target updates from agents and feeds them into the platform.
-
-| Panel | Metric | What to watch for |
-|-------|--------|-------------------|
-| Message Queue Length | `queue_size` | A non-zero value sustained for minutes means the platform is falling behind. |
-| Message Creation Rate | rate of `queue_messages_total` | Incoming load. Compare with throughput. |
-| Message Queue Accumulated Lead Time | `queue_lead_time` | Most important latency indicator for ingestion. |
-| Target Post Processing Throughput | rate of `target_post_processing_seconds_count` | Should match or exceed the creation rate. |
-| Target Post Processing Latency (p95) | `target_post_processing_seconds` | Per-processor breakdown helps identify slow steps. |
-
-### Target Ingestion
-
-Validates that targets discovered by agents are being received and stored.
-
-| Panel | What it shows |
-|-------|---------------|
-| Targets by Type | Distribution of target types currently in the platform. |
-| Target & EnrichmentData Count / by Type | Total target count over time — a sudden drop is a red flag. |
-| Target Submit Count | Submissions per second from agents. |
-| Agents registered | Count of agents currently connected per tenant. A drop indicates connectivity loss. |
-
-### Platform Chaos Engineering Activity
-
-Business-level signals that confirm Steadybit is being used.
-
-| Panel | Metric |
-|-------|--------|
-| Experiment(s) running | `platform.experiments.executing` |
-| Experiments executed (7 days) | Long-window counter, useful as a lagging indicator. |
-| Number of active users | Useful before maintenance windows. See [Maintenance & Incident Support](maintenance-and-incident-support.md). |
-
-### Platform Resource Consumption
-
-The infrastructure-level signals to alert on.
-
-| Panel | Metric |
-|-------|--------|
-| Platform CPU Usage | `process_cpu_usage` |
-| Thread Pool Usage | `executor_active_threads` per executor |
-| Datasource connections | `hikaricp_connections_active` per pool |
-| Quartz Job Activity | Background jobs running on schedule. |
-| Outgoing Requests | `connectivity_outgoing_address_filter_total` (allowed / blocked) |
-| Platform Log Events | Rate of `error` and `warn` log lines. |
+To install, in Grafana go to **Dashboards → New → Import**, then either upload the file or paste its contents. Select your Prometheus data source when prompted.
 
 ## Recommended Prometheus Alert Rules
 

--- a/install-and-configure/install-on-prem-platform/monitoring.md
+++ b/install-and-configure/install-on-prem-platform/monitoring.md
@@ -28,8 +28,6 @@ Port `9090` is administrative and is not exposed to end users. Scrape it from yo
 
 ## The Four Golden Signals
 
-Monitor these four families first. They cover almost every customer-facing problem.
-
 ### 1. Latency
 
 How long requests take to complete. Two views matter:
@@ -179,26 +177,6 @@ spec:
           labels: { severity: critical }
           annotations:
             summary: "HikariCP pool {{ $labels.pool }} > 80 % utilized"
-```
-
-### Optional: Security & Rate Limit Alerts
-
-If your platform is exposed to user-defined webhooks or hubs, the following alerts help catch abusive or misconfigured integrations:
-
-```yaml
-- alert: SteadybitBlockedOutgoingRequests
-  expr: sum by(status) (increase(connectivity_outgoing_address_filter_total{status="blocked"}[1m])) > 5
-  for: 1m
-  labels: { severity: warning }
-  annotations:
-    summary: "Outgoing webhook or hub requests are being blocked"
-
-- alert: SteadybitTenantRateLimitReached
-  expr: |
-    avg by (tenantKey, bucketName) (avg_over_time((ratelimit_tokens_available{qualifier="none"})[10m:])) <= 1
-  labels: { severity: warning }
-  annotations:
-    summary: "Tenant rate limit reached: tenant={{ $labels.tenantKey }}, bucket={{ $labels.bucketName }}"
 ```
 
 ## When an Alert Fires


### PR DESCRIPTION
## Summary

Adds two customer-facing pages under **Install On-Prem Platform** so operators have a clear path to monitor the platform and recover from the most common database incidents.

- **`monitoring.md`** — Prometheus endpoint, the four Golden Signals (latency, traffic, errors, saturation) with the thresholds we run internally, a reference to each Grafana dashboard panel from our ops board, and a ready-to-paste `PrometheusRule` manifest covering golden signals + optional security/rate-limit alerts. Triage table maps each alert to its first investigation step.
- **`database-runbooks.md`** — Runbooks for the two situations we see most often:
  - **Blocking transactions**: locate via `pg_stat_activity` + `pg_locks`, terminate with `pg_terminate_backend`.
  - **Running out of disk space**: top-tables query, `VACUUM FULL`, retention deletes, volume resize.
  - Includes a "Preventive Maintenance" section pointing to the existing `STEADYBIT_DB_MAINTENANCE_*` config.

Both pages cross-link to each other, to the existing on-prem troubleshooting page, and to advanced configuration. Registered in `SUMMARY.md` between *Configuration Options* and *Maintenance & Incident Support*.

## Test plan

- [ ] Verify pages render correctly in the GitBook preview
- [ ] Confirm internal links resolve (between the two new pages and to existing pages)
- [ ] Confirm the navigation entries appear in the expected order under *Install On-Prem Platform*
- [ ] Sanity-check that the YAML in the recommended `PrometheusRule` is valid (e.g. `kubectl apply --dry-run=client -f`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)