### PR TITLE
doc: allow renaming OIDC-managed teams

### DIFF
--- a/install-and-configure/install-on-prem-platform/oidc-integration.md
+++ b/install-and-configure/install-on-prem-platform/oidc-integration.md
@@ -94,7 +94,8 @@ During authentication, the platform inspects the returned OIDC ID token for the 
 
 Teams and memberships created through OIDC synchronization are marked as **managed by OIDC**. This has the following effects:
 
-- **Team name and key** of OIDC-managed teams cannot be edited by platform admins. They are controlled by the IdP.
+- **Team key** of OIDC-managed teams cannot be edited by platform admins — it is controlled by the IdP.
+- **Team name** of OIDC-managed teams can be edited by platform admins. The IdP-provided name is used when the team is first created; subsequent OIDC syncs do not overwrite the team name, so renames made in Steadybit are preserved.
 - **OIDC-managed members** cannot be removed from teams via the UI or API by platform admins. Membership changes must be made in the IdP.
 - **Manually added members** on an OIDC-managed team are preserved and can be managed normally. OIDC synchronization only affects OIDC-managed memberships.
 - Other team properties (description, allowed environments, allowed actions) remain editable by admins.


### PR DESCRIPTION
## Summary

- Update `oidc-integration.md` to reflect the platform change that OIDC-managed team names are now editable by platform admins.
- Clarify that the IdP-provided name is used at team creation, and subsequent OIDC syncs no longer overwrite manually-chosen names. Key remains immutable.

Pairs with platform commit https://github.com/steadybit/platform/commit/b88bec9a8e (ticket 18731).

Linked: https://steadybitgmbh.kanbanize.com/ctrl_board/2/cards/18731

## Test plan

- [ ] Render `install-and-configure/install-on-prem-platform/oidc-integration.md` and confirm the OIDC effects bullet list reads correctly.
- [ ] Verify no other docs cross-reference the removed "name cannot be edited" statement for OIDC.