### PR TITLE
docs: evaluation scope for dynamic service variables

### DIFF
--- a/use-steadybit/experiments/variables.md
+++ b/use-steadybit/experiments/variables.md
@@ -43,6 +43,8 @@ Service-scoped variables are defined on a [service](../services/README.md#variab
 
 Use service variables to align common configuration across all of a service's experiments, for example a service-specific base URL, namespace, or duration, without repeating it in every experiment. Service variables can also be referenced inside the service's [validation](../services/README.md#validations) definitions.
 
+When a service variable holds a [dynamic value](#dynamic-value), you additionally choose its **evaluation scope**: whether the value is sampled from the service's own targets (the default) or from the whole environment the service lives in. See [Dynamic Value](#dynamic-value) for details.
+
 {% hint style="info" %}
 When an experiment is linked to **multiple services** and more than one of them defines the same variable key, the service that was associated later takes precedence.
 {% endhint %}
@@ -95,6 +97,13 @@ A dynamic value is not typed by hand. Instead, it is selected from your live inf
 - Filter _(optional)_ — a query that restricts the candidate targets before a value is picked (e.g., only pods in a certain namespace).
 
 You also control the **cardinality** of the selection, how many of the matching values are picked: a single value or several. When more than one value is selected, the variable carries the whole set. In a blast-radius query such as `... IN ({{var}})` it expands to one comparison value per selected value; where a single string is expected, the selected values are combined into a comma-separated list.
+
+For a dynamic value on a [service variable](#service), you additionally choose the **evaluation scope**, i.e. which targets the value is sampled from:
+
+- **Service's targets** _(default)_ — only the service's own targets are considered: the service's environment narrowed by the service's [target query](../services/README.md).
+- **Service's environment** — all targets in the environment the service lives in are considered, ignoring the service's query.
+
+The evaluation scope only applies to service variables. For environment, experiment, and run variables a dynamic value is always sampled from the environment.
 
 Use dynamic values when the concrete value isn't known up front or should adapt to the current state of your infrastructure, for example, to attack a representative pod that actually exists at run time rather than hard-coding a name, or to vary the affected target between runs.
 

--- a/use-steadybit/experiments/variables.md
+++ b/use-steadybit/experiments/variables.md
@@ -43,7 +43,7 @@ Service-scoped variables are defined on a [service](../services/README.md#variab
 
 Use service variables to align common configuration across all of a service's experiments, for example a service-specific base URL, namespace, or duration, without repeating it in every experiment. Service variables can also be referenced inside the service's [validation](../services/README.md#validations) definitions.
 
-When a service variable holds a [dynamic value](#dynamic-value), you additionally choose its **evaluation scope**: whether the value is sampled from the service's own targets (the default) or from the whole environment the service lives in. See [Dynamic Value](#dynamic-value) for details.
+When a service variable holds a [dynamic value](#dynamic-value), you additionally choose its **evaluation scope**: whether the value is sampled from the service's own targets (the default) or from the whole environment the service lives in. See [Evaluation scope](#evaluation-scope) for details.
 
 {% hint style="info" %}
 When an experiment is linked to **multiple services** and more than one of them defines the same variable key, the service that was associated later takes precedence.
@@ -90,29 +90,36 @@ Use a fixed value for stable, well-known configuration, for example a Kubernetes
 
 ### Dynamic Value
 
-A dynamic value is not typed by hand. Instead, it is selected from your live infrastructure when the experiment run starts. You configure it as _"select one value of a target attribute on a target type"_, optionally narrowed by a filter query:
+A dynamic value is not typed by hand. Instead, it is selected from your live infrastructure when the experiment run starts. You configure it as _"select one or more values of a target attribute on a target type"_.
+
+Use dynamic values when the specific value isn't known up front or should adapt to the current state of your infrastructure. For example, you might attack a pod that actually exists at run time rather than hard-coding a name, or vary the affected target between runs.
+
+The configuration consists of:
 
 - Target type — the kind of target to read the value from (e.g., a Kubernetes pod, a host, an AWS EC2 instance).
 - Attribute — the target attribute whose value should be used (e.g., the pod name, host name, or an AWS instance id).
+- Evaluation scope _(only for service variables)_ — whether to sample from the service's own targets or the whole environment (see [Evaluation scope](#evaluation-scope)).
 - Filter _(optional)_ — a query that restricts the candidate targets before a value is picked (e.g., only pods in a certain namespace).
 
 You also control the **cardinality** of the selection, how many of the matching values are picked: a single value or several. When more than one value is selected, the variable carries the whole set. In a blast-radius query such as `... IN ({{var}})` it expands to one comparison value per selected value; where a single string is expected, the selected values are combined into a comma-separated list.
 
+#### Evaluation scope
+
 For a dynamic value on a [service variable](#service), you additionally choose the **evaluation scope**, i.e. which targets the value is sampled from:
 
-- **Service's targets** _(default)_ — only the service's own targets are considered: the service's environment narrowed by the service's [target query](../services/README.md).
-- **Service's environment** — all targets in the environment the service lives in are considered, ignoring the service's query.
+- **Only targets of this service** _(default)_ — only the service's own targets are considered: the service's environment narrowed by the service's [target query](../services/README.md#target-scope).
+- **All targets of this service's environment** — all targets in the environment the service lives in are considered, ignoring the service's query.
 
-The evaluation scope only applies to service variables. For environment, experiment, and run variables a dynamic value is always sampled from the environment.
+The evaluation scope only applies to service variables. For environment, experiment, and run variables, a dynamic value is always sampled from the environment.
 
-Use dynamic values when the concrete value isn't known up front or should adapt to the current state of your infrastructure, for example, to attack a representative pod that actually exists at run time rather than hard-coding a name, or to vary the affected target between runs.
+#### Run-time resolution
 
-Because a dynamic value depends on the live target index, it is resolved at the start of each run (not at design time). The selected value or values then stay stable for the entire experiment run, every step that references the variable uses the same selection, and the resolution happens again only on the next run. The concrete value that was selected for a given run can be inspected afterward in the [resolved variables](#resolved-variables-in-experiment-run) view.
+Because a dynamic value depends on the live target index, it is resolved at the start of each run (not at experiment design time). The selected value or values then stay stable for the entire experiment run, every step that references the variable uses the same selection, and the resolution happens again only on the next run. The concrete value that was selected for a given run can be inspected afterward in the [resolved variables](#resolved-variables-in-experiment-run) view.
 
 ![Dynamic Variable Value](./variable-value-settings-dynamic.png)
 
 {% hint style="info" %}
-A dynamic value resolves to a value of the target index. If, at run time, no target matches the configured type and filter, the variable cannot be resolved and the experiment run will report the unresolved variable.
+A dynamic value resolves to a value from the target index. If, at run time, no target matches the configured type and filter, the variable cannot be resolved and the experiment run will report the unresolved variable.
 {% endhint %}
 
 ## Referencing Other Variables

--- a/use-steadybit/services/README.md
+++ b/use-steadybit/services/README.md
@@ -162,7 +162,7 @@ For example, add `OR datadog.monitor.tags="env:stage"` when using Datadog Monito
 
 Service variables can be used to abstract and align common properties throughout all experiments of the service. In this functionality they extend or override [variables of the associated environment](../../install-and-configure/manage-environments/README.md#environment-variables), and can themselves be overridden by experiment variables or per-run overrides.
 
-They apply to both the experiments provided by the service and custom experiments linked to it, and can also be referenced inside this service's [validations](#validations). Like other variables, a service variable can hold a [fixed or a dynamic value](../../use-steadybit/experiments/variables.md#fixed-and-dynamic-values).
+They apply to both the experiments provided by the service and custom experiments linked to it, and can also be referenced inside this service's [validations](#validations). Like other variables, a service variable can hold a [fixed or a dynamic value](../../use-steadybit/experiments/variables.md#fixed-and-dynamic-values). For a dynamic value, you also choose its evaluation scope — whether it is sampled from the service's own [target scope](#target-scope) (the default) or from the whole environment the service lives in.
 
 You can [learn more in the experiment's variable section](../../use-steadybit/experiments/variables.md#service).
 

--- a/use-steadybit/services/README.md
+++ b/use-steadybit/services/README.md
@@ -162,7 +162,7 @@ For example, add `OR datadog.monitor.tags="env:stage"` when using Datadog Monito
 
 Service variables can be used to abstract and align common properties throughout all experiments of the service. In this functionality they extend or override [variables of the associated environment](../../install-and-configure/manage-environments/README.md#environment-variables), and can themselves be overridden by experiment variables or per-run overrides.
 
-They apply to both the experiments provided by the service and custom experiments linked to it, and can also be referenced inside this service's [validations](#validations). Like other variables, a service variable can hold a [fixed or a dynamic value](../../use-steadybit/experiments/variables.md#fixed-and-dynamic-values). For a dynamic value, you also choose its evaluation scope — whether it is sampled from the service's own [target scope](#target-scope) (the default) or from the whole environment the service lives in.
+They apply to both the experiments provided by the service and custom experiments linked to it, and can also be referenced inside this service's [validations](#validations). Like other variables, a service variable can hold a [fixed or a dynamic value](../../use-steadybit/experiments/variables.md#fixed-and-dynamic-values). For a dynamic value, you also choose its [evaluation scope](../../use-steadybit/experiments/variables.md#evaluation-scope) — whether it is sampled from the service's own [target scope](#target-scope) (the default) or from the whole environment the service lives in.
 
 You can [learn more in the experiment's variable section](../../use-steadybit/experiments/variables.md#service).
 


### PR DESCRIPTION
Documents the new **evaluation scope** for dynamic (select) values on **service** variables, added in platform PR [steadybit/platform#1595](https://github.com/steadybit/platform/pull/1595).

## What
- **`use-steadybit/experiments/variables.md`**
  - *Dynamic Value*: explains the evaluation scope with both options — **Service's targets** (default; the service's environment narrowed by the service's target query) and **Service's environment** (the whole environment, ignoring the service query), plus a note that it only applies to service variables.
  - *Service*: short pointer to the scope choice for dynamic service variables.
- **`use-steadybit/services/README.md`**: matching one-liner in the Variables section.

Edits only — no new pages, so `SUMMARY.md`/redirects are untouched. All anchors resolve to existing headings.